### PR TITLE
spring-boot-rest-prometheus to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -39,4 +39,4 @@ dependencies:
   version: 0.0.1
 - name: spring-boot-rest-prometheus
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.5


### PR DESCRIPTION
Promote spring-boot-rest-prometheus to version 0.0.5